### PR TITLE
feat: make the new rust-it-coverage target work

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -32,3 +32,5 @@ logtest
 oneshot
 Stuckee
 Refactorings
+Lcov
+seccomp

--- a/.env.repo
+++ b/.env.repo
@@ -1,17 +1,18 @@
 # Space seperated list of features that needs to be tested on their own
 # Needs to be quoted if multiple entries are used
 EXCLUSIVE_FEATURES_TEST="stub_client"
+
 # Comma seperated list of features that needs to be enabled for test/ build/ release
-PACKAGE_TEST_FEATURES=test_util
+PACKAGE_UT_FEATURES=test_util
+PACKAGE_IT_FEATURES=stub_backends
 PACKAGE_BUILD_FEATURES=default
 PACKAGE_RELEASE_FEATURES=default
+
+# Create the 'dev' image with stub_backends feature enabled if you want to run the server
+# without the need of spinning up all dependend services.
 DOCKER_DEV_FEATURES=stub_backends
 
 # REST Server settings
 REST_CONCURRENCY_LIMIT_PER_SERVICE=5
 REST_REQUEST_LIMIT_PER_SECOND=2
 REST_CORS_ALLOWED_ORIGIN=http://localhost:3000
-
-# GRPC Client settings
-STORAGE_HOST_GRPC=svc-storage
-STORAGE_PORT_GRPC=50011

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -17,12 +17,7 @@ test_util = ["mock", "stub_backends", "tokio"]
 # Will add a 'mock' module for the enabled resources, providing access to mock data generation functions
 mock = []
 # Will use a stubbed server connection, only use for tests!
-stub_backends = [
-  "svc-template-rust/stub_server",
-  "lib-common/grpc_mock",
-  "tower",
-  "tokio",
-]
+stub_backends = ["svc-template-rust", "lib-common/grpc_mock", "tower", "tokio"]
 # Will implement stub functions for the client, only use for tests!
 stub_client = ["svc-template-rust"]
 

--- a/client-grpc/src/client.rs
+++ b/client-grpc/src/client.rs
@@ -65,7 +65,7 @@ mod tests {
     async fn test_client_connect() {
         let name = "template_rust";
         let (server_host, server_port) =
-            lib_common::grpc::get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+            lib_common::grpc::get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
 
         let client: TemplateRustClient = GrpcClient::new_client(&server_host, server_port, name);
         assert_eq!(client.get_name(), name);
@@ -79,7 +79,7 @@ mod tests {
     async fn test_client_is_ready_request() {
         let name = "template_rust";
         let (server_host, server_port) =
-            lib_common::grpc::get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+            lib_common::grpc::get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
 
         let client: TemplateRustClient = GrpcClient::new_client(&server_host, server_port, name);
         assert_eq!(client.get_name(), name);

--- a/client-grpc/tests/integration_test.rs
+++ b/client-grpc/tests/integration_test.rs
@@ -7,7 +7,7 @@ fn get_log_string(function: &str, name: &str) -> String {
     #[cfg(not(feature = "stub_client"))]
     cfg_if::cfg_if! {
         if #[cfg(feature = "stub_backends")] {
-            return format!("({} MOCK) {} server.", function, name);
+            return format!("({}) {} server.", function, name);
         } else {
             return format!("({}) {} client.", function, name);
         }
@@ -22,7 +22,7 @@ async fn test_client_requests_and_logs() {
 
     let name = "template_rust";
     let (server_host, server_port) =
-        lib_common::grpc::get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+        lib_common::grpc::get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
 
     let client = TemplateRustClient::new_client(&server_host, server_port, name);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+configs:
+  log4rs:
+    file: log4rs.yaml
+  dot-env:
+    file: .env
+
+services:
+  web-server:
+    extends:
+      file: docker-compose-base.yml
+      service: web-server
+
+  example:
+    extends:
+      file: docker-compose-base.yml
+      service: example
+
+  ut-coverage:
+    extends:
+      file: docker-compose-base.yml
+      service: ut-coverage
+
+  it-coverage:
+    extends:
+      file: docker-compose-base.yml
+      service: it-coverage

--- a/server/src/rest/api.rs
+++ b/server/src/rest/api.rs
@@ -127,7 +127,7 @@ mod tests {
         ut_info!("(test_health_check_success) Start.");
 
         // Mock the GrpcClients extension
-        let config = crate::Config::try_from_env().unwrap_or_default();
+        let config = crate::Config::default();
         let grpc_clients = GrpcClients::default(config); // Replace with your own mock implementation
 
         // Call the health_check function


### PR DESCRIPTION
Adds a basis for the docker-compose.yml file which is not provisioned by terraform anymore.
Also fixes some issues that popped up while running the new `rust-it-coverage` target.